### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/code/Hierarchical_Attention_Networks/textClassifierConv.py
+++ b/code/Hierarchical_Attention_Networks/textClassifierConv.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # author - Richard Liao
 # Dec 26 2016
 import numpy as np
@@ -38,7 +39,7 @@ def clean_str(string):
     return string.strip().lower()
 
 data_train = pd.read_csv('~/Testground/data/imdb/labeledTrainData.tsv', sep='\t')
-print data_train.shape
+print(data_train.shape)
 
 texts = []
 labels = []
@@ -59,8 +60,8 @@ print('Found %s unique tokens.' % len(word_index))
 data = pad_sequences(sequences, maxlen=MAX_SEQUENCE_LENGTH)
 
 labels = to_categorical(np.asarray(labels))
-print('Shape of data tensor:', data.shape)
-print('Shape of label tensor:', labels.shape)
+print(('Shape of data tensor:', data.shape))
+print(('Shape of label tensor:', labels.shape))
 
 indices = np.arange(data.shape[0])
 np.random.shuffle(indices)
@@ -74,8 +75,8 @@ x_val = data[-nb_validation_samples:]
 y_val = labels[-nb_validation_samples:]
 
 print('Number of positive and negative reviews in traing and validation set ')
-print y_train.sum(axis=0)
-print y_val.sum(axis=0)
+print(y_train.sum(axis=0))
+print(y_val.sum(axis=0))
 
 GLOVE_DIR = "/ext/home/analyst/Testground/data/glove"
 embeddings_index = {}

--- a/code/Hierarchical_Attention_Networks/textClassifierHATT.py
+++ b/code/Hierarchical_Attention_Networks/textClassifierHATT.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # author - Richard Liao 
 # Dec 26 2016
 import numpy as np
@@ -43,7 +44,7 @@ def clean_str(string):
     return string.strip().lower()
 
 data_train = pd.read_csv('~/Testground/data/imdb/labeledTrainData.tsv', sep='\t')
-print data_train.shape
+print(data_train.shape)
 
 from nltk import tokenize
 
@@ -79,8 +80,8 @@ word_index = tokenizer.word_index
 print('Total %s unique tokens.' % len(word_index))
 
 labels = to_categorical(np.asarray(labels))
-print('Shape of data tensor:', data.shape)
-print('Shape of label tensor:', labels.shape)
+print(('Shape of data tensor:', data.shape))
+print(('Shape of label tensor:', labels.shape))
 
 indices = np.arange(data.shape[0])
 np.random.shuffle(indices)
@@ -94,8 +95,8 @@ x_val = data[-nb_validation_samples:]
 y_val = labels[-nb_validation_samples:]
 
 print('Number of positive and negative reviews in traing and validation set')
-print y_train.sum(axis=0)
-print y_val.sum(axis=0)
+print(y_train.sum(axis=0))
+print(y_val.sum(axis=0))
 
 GLOVE_DIR = "/ext/home/analyst/Testground/data/glove"
 embeddings_index = {}
@@ -138,7 +139,7 @@ model.compile(loss='categorical_crossentropy',
               metrics=['acc'])
 
 print("model fitting - Hierachical LSTM")
-print model.summary()
+print(model.summary())
 model.fit(x_train, y_train, validation_data=(x_val, y_val),
           nb_epoch=10, batch_size=50)
 

--- a/code/Hierarchical_Attention_Networks/textClassifierRNN.py
+++ b/code/Hierarchical_Attention_Networks/textClassifierRNN.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # author - Richard Liao
 # Dec 26 2016
 import numpy as np
@@ -42,7 +43,7 @@ def clean_str(string):
     return string.strip().lower()
 
 data_train = pd.read_csv('~/Testground/data/imdb/labeledTrainData.tsv', sep='\t')
-print data_train.shape
+print(data_train.shape)
 
 texts = []
 labels = []
@@ -63,8 +64,8 @@ print('Found %s unique tokens.' % len(word_index))
 data = pad_sequences(sequences, maxlen=MAX_SEQUENCE_LENGTH)
 
 labels = to_categorical(np.asarray(labels))
-print('Shape of data tensor:', data.shape)
-print('Shape of label tensor:', labels.shape)
+print(('Shape of data tensor:', data.shape))
+print(('Shape of label tensor:', labels.shape))
 
 indices = np.arange(data.shape[0])
 np.random.shuffle(indices)
@@ -78,8 +79,8 @@ x_val = data[-nb_validation_samples:]
 y_val = labels[-nb_validation_samples:]
 
 print('Traing and validation set number of positive and negative reviews')
-print y_train.sum(axis=0)
-print y_val.sum(axis=0)
+print(y_train.sum(axis=0))
+print(y_val.sum(axis=0))
 
 GLOVE_DIR = "~/Testground/data/glove"
 embeddings_index = {}


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.